### PR TITLE
Fix bower paths in grunt server task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -172,11 +172,20 @@ module.exports = function(grunt) {
           dest: '.tmp/assets/css',
           src: ['{,*/}*.css']
         }]
+      },
+      bower: {
+        files: [{
+          expand: true,
+          cwd: './bower_components',
+          dest: '.tmp/bower_components',
+          src: ['**/*.*']
+        }]
       }
     },
     concurrent: {
       server: [
-        'copy:styles'
+        'copy:styles',
+        'copy:bower'
       ],
       test: [
         'copy:styles'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -185,13 +185,14 @@ module.exports = function(grunt) {
     concurrent: {
       server: [
         'copy:styles',
-        'copy:bower'
       ],
       test: [
-        'copy:styles'
+        'copy:styles',
+        'copy:bower'
       ],
       dist: [
-        'copy:styles'
+        'copy:styles',
+        'copy:bower'
       ]
     },
     mox: {

--- a/README.md
+++ b/README.md
@@ -2,4 +2,12 @@ D4 - Examples
 
 *************
 
+This is the examples page for [d4](https://github.com/heavysixer/d4).
+
+To view the examples, do the following:
+
+1. Clone d4 into a sibling directory to this repo
+2. Run `npm install && bower install`
+3. Run `grunt server` and view the page at `localhost:3000`
+
 Open dist/index.html in your favorite browser to begin using the d4 examples site.

--- a/src/templates/layouts/default.hbs
+++ b/src/templates/layouts/default.hbs
@@ -20,7 +20,7 @@
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
     <!-- build:js({.tmp,src}) {{assets}}/js/jquery.js -->
-    <script src="{{src}}/bower_components/jquery/jquery.js"></script>
+    <script src="{{src}}/bower_components/jquery/dist/jquery.js"></script>
     <!-- endbuild -->
     <!-- build:js({.tmp,src}) {{assets}}/js/main.js -->
     <script src="{{src}}/assets/js/main.js"></script>


### PR DESCRIPTION
The bower components were not being copied to the `.tmp` directory. This was causing the page created by `grunt server` to 404 on all bower components.
